### PR TITLE
Adopt args.hpp for using in multiple translation units

### DIFF
--- a/include/args.hpp
+++ b/include/args.hpp
@@ -115,7 +115,7 @@ void each_arg(F f, Ts&&... xs)
 }
 #endif
 
-std::vector<std::string> wrap(const std::string& text, unsigned int line_length = 72)
+static inline std::vector<std::string> wrap(const std::string& text, unsigned int line_length = 72)
 {
     std::vector<std::string> output;
     std::istringstream iss(text);
@@ -234,7 +234,7 @@ void write_value_to(T& result, const std::string& x)
     result.insert(result.end(), value_parser<typename T::value_type>::apply(x));
 }
 
-void write_value_to(std::nullptr_t, const std::string&)
+static inline void write_value_to(std::nullptr_t, const std::string&)
 {
     // Do nothing
 }
@@ -468,7 +468,7 @@ auto show(T text)
     return action([=]{ std::cout << text << std::endl; });
 }
 
-auto required()
+static inline auto required()
 {
     return [](auto&&, auto&, argument& a)
     {
@@ -491,7 +491,7 @@ auto set(T value)
     };
 }
 
-auto count()
+static inline auto count()
 {
     return [](auto&& data, auto&, argument& a)
     {
@@ -554,7 +554,7 @@ std::string pop_string(Iterator first, Iterator last)
     else return std::string(first+1, last);
 }
 
-std::tuple<std::string, std::string> parse_attached_value(const std::string& s)
+static inline std::tuple<std::string, std::string> parse_attached_value(const std::string& s)
 {
     assert(s.size() > 0);
     assert(s[0] == '-' && "Not parsing a flag");


### PR DESCRIPTION
There were linker errors about duplicated symbols for all free functions in the library: count, required, wrap, write_value_to, parse_attached_value. For example:

```
duplicate symbol 'args::count()' in:
    bazel-out/.../apps/cli/libsources.a(main.o)
    bazel-out/.../apps/cli/libsources.a(app.o)
```